### PR TITLE
Ctl-B to perform the same as Ctl-`

### DIFF
--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -181,14 +181,15 @@ namespace ClipBoard
 
         public void keyPressedHandler(Keys keys)
         {
-            //control-` pressed
-            if ((ModifierKeys & Keys.Control) == Keys.Control && keys == Keys.Oemtilde)
+            Keys ModKeys = ModifierKeys; // save locally to aid debugging
+            //control-` pressed or control-shift-b
+            if ((ModKeys & Keys.Control) == Keys.Control && (keys == Keys.Oemtilde || keys == Keys.B))
             {
                 showScreen();
             }
 
-            //control-p pressed
-            if ((ModifierKeys & Keys.Control) == Keys.Control && keys == Keys.V)
+            //control-v pressed
+            if ((ModKeys & Keys.Control) == Keys.Control && keys == Keys.V)
             {
                 recordPaste();
             }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ clipboard when a "Copy" is performed.
 - Right click an item to save it to the frequently used items list on the top
 - Right click and click remove to remove the selected item
 - Minimize to hide the tool to system tray
-- ``Ctrl+```(ctrl+backtick) to bring the tool up
+- ``Ctrl+```(ctrl+backtick) or Ctrl+b to bring the tool up
 - Clicking on an item also hide the tool to system tray
 
 


### PR DESCRIPTION
Added code such that Ctl-B to perform the same as Ctl-`.
On some keyboards Ctl-` was not working and 'B' is next to 'V' on qwerty
keyboards so this combination does not feel unnatural to perform.
